### PR TITLE
increase message size to 250

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -7,9 +7,22 @@ namespace RazorPagesTestSample.Data
     {
         public int Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the text of the message.
+        /// </summary>
+        /// <value>
+        /// The text content of the message, limited to 250 characters.
+        /// </value>
+        /// <remarks>
+        /// This property is required and must be a text data type. If the text exceeds 250 characters, an error message will be displayed.
+        /// </remarks>
+        /// <exception cref="ValidationException">
+        /// Thrown when the text exceeds 250 characters or is not provided.
+        /// </exception>
+        /// /// /// /// /// /// /// /// /// /// /// 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes a change to the `Message` class in the `RazorPagesTestSample` project to improve the documentation and validation of the `Text` property.

Enhancements to `Message` class:

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450R10-R25): Added XML documentation for the `Text` property, including a summary, value description, remarks, and exception details. Increased the character limit for the `Text` property from 200 to 250 characters.